### PR TITLE
Set the dispatch time so that queue time tracking works

### DIFF
--- a/metrics-jetty/src/main/java/com/yammer/metrics/jetty/InstrumentedHandler.java
+++ b/metrics-jetty/src/main/java/com/yammer/metrics/jetty/InstrumentedHandler.java
@@ -184,6 +184,7 @@ public class InstrumentedHandler extends HandlerWrapper {
         final boolean isMilliseconds;
 
         if (continuation.isInitial()) {
+            request.setDispatchTime(request.getConnection().getTimeStamp());
             activeRequests.inc();
             start = request.getTimeStamp();
             isMilliseconds = true;


### PR DESCRIPTION
This makes queue time tracking work for me in the dropwizard access logs. I tried it once with no concurrency (hence no queueing) and high concurrency (lots of queueing) and put the access log output here: https://git.hubteam.com/gist/jhaber/bdab84c9c18ef5e9dbc499fa6bdce420

@axiak @jaredmiwilliams
