### PR TITLE
Add a separate RequestDurationTracker to allow other metrics

### DIFF
--- a/metrics-jetty/src/main/java/com/yammer/metrics/jetty/RequestDurationTracker.java
+++ b/metrics-jetty/src/main/java/com/yammer/metrics/jetty/RequestDurationTracker.java
@@ -1,0 +1,13 @@
+package com.yammer.metrics.jetty;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A RequestDurationTracker is used to track queue and request
+ * times as they occur.
+ * DO NOT BLOCK IN ConnectionMetricTracker CALLS AS THEY WILL BLOCK THE REQUEST THREAD
+ */
+public interface RequestDurationTracker {
+  void acceptQueueTime(long time, TimeUnit timeUnit);
+  void acceptRequestAndQueueTime(long time, TimeUnit timeUnit);
+}


### PR DESCRIPTION
This will allow more customized tracking of queue times as they
occur. For instance, this might allow one to have a real time view
of whether or not the request queue is backed up.

---

@jhaber @jaredmiwilliams
