### PR TITLE
Use biased histogram by default

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/core/MetricsRegistry.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/MetricsRegistry.java
@@ -224,7 +224,7 @@ public class MetricsRegistry {
      */
     public Histogram newHistogram(Class<?> klass,
                                   String name) {
-        return newHistogram(klass, name, false);
+        return newHistogram(klass, name, true);
     }
 
     /**
@@ -239,7 +239,7 @@ public class MetricsRegistry {
     public Histogram newHistogram(Class<?> klass,
                                   String name,
                                   String scope) {
-        return newHistogram(klass, name, scope, false);
+        return newHistogram(klass, name, scope, true);
     }
 
     /**


### PR DESCRIPTION
By default, use a biased histogram. Users can still get the unbiased (infinite history) histogram via the ctors with explicit bias.

@jhaber @axiak 
