### PR TITLE
Update Histogram docs in MetricsRegistry

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/core/MetricsRegistry.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/MetricsRegistry.java
@@ -232,7 +232,7 @@ public class MetricsRegistry {
     }
 
     /**
-     * Creates a new non-biased {@link Histogram} and registers it under the given class and name.
+     * Creates a new biased {@link Histogram} and registers it under the given class and name.
      *
      * @param klass the class which owns the metric
      * @param name  the name of the metric
@@ -244,7 +244,7 @@ public class MetricsRegistry {
     }
 
     /**
-     * Creates a new non-biased {@link Histogram} and registers it under the given class, name, and
+     * Creates a new biased {@link Histogram} and registers it under the given class, name, and
      * scope.
      *
      * @param klass the class which owns the metric


### PR DESCRIPTION
Those 2 methods are passing a `true` boolean for the biased parameter. Changed the docs to reflect how the Histogram is constructed. 

I don't know if you prefer the default to be a non-biased `Histogram`, changing the passed parameter instead of the docs.