### PR TITLE
Add Gauge#newGauge to ease Gauge creation

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/core/Gauge.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/Gauge.java
@@ -1,5 +1,6 @@
 package com.yammer.metrics.core;
 
+import java.util.function.Supplier;
 
 /**
  * A gauge metric is an instantaneous reading of a particular value. To instrument a queue's depth,
@@ -26,5 +27,14 @@ public abstract class Gauge<T> implements Metric {
     @Override
     public <U> void processWith(MetricProcessor<U> processor, MetricName name, U context) throws Exception {
         processor.processGauge(name, this, context);
+    }
+
+    public static <T> Gauge<T> newGauge(Supplier<T> valueSupplier) {
+        return new Gauge<T>() {
+            @Override
+            public T value() {
+                return valueSupplier.get();
+            }
+        };
     }
 }

--- a/metrics-core/src/main/java/com/yammer/metrics/core/Gauge.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/Gauge.java
@@ -29,7 +29,7 @@ public abstract class Gauge<T> implements Metric {
         processor.processGauge(name, this, context);
     }
 
-    public static <T> Gauge<T> newGauge(Supplier<T> valueSupplier) {
+    public static <T> Gauge<T> of(Supplier<T> valueSupplier) {
         return new Gauge<T>() {
             @Override
             public T value() {


### PR DESCRIPTION
This should remove the need for anonymous implementations of `Gauge`. I don't think that changing gauge to an interface is reasonable here.

I was also updating `MetricsRegistry` to add methods that take a `Gauge`, but just this change seems good enough.

@jhaber @szabowexler @kmclarnon 