### PR TITLE
Make installing InstrumentationModule idempotent

### DIFF
--- a/metrics-guice/src/main/java/com/yammer/metrics/guice/InstrumentationModule.java
+++ b/metrics-guice/src/main/java/com/yammer/metrics/guice/InstrumentationModule.java
@@ -1,5 +1,7 @@
 package com.yammer.metrics.guice;
 
+import java.util.Objects;
+
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
 import com.google.inject.matcher.Matchers;
@@ -21,11 +23,13 @@ import com.yammer.metrics.reporting.JmxReporter;
  * @see GaugeInjectionListener
  */
 public class InstrumentationModule extends AbstractModule {
+    private final HealthCheckRegistry healthCheckRegistry = createHealthCheckRegistry();
+    private final MetricsRegistry metricsRegistry = createMetricsRegistry();
+
     @Override
     protected void configure() {
-        final MetricsRegistry metricsRegistry = createMetricsRegistry();
         bind(MetricsRegistry.class).toInstance(metricsRegistry);
-        bind(HealthCheckRegistry.class).toInstance(createHealthCheckRegistry());
+        bind(HealthCheckRegistry.class).toInstance(healthCheckRegistry);
         bindJmxReporter();
         bindListener(Matchers.any(), new MeteredListener(metricsRegistry));
         bindListener(Matchers.any(), new TimedListener(metricsRegistry));
@@ -52,5 +56,23 @@ public class InstrumentationModule extends AbstractModule {
      */
     protected MetricsRegistry createMetricsRegistry() {
         return Metrics.defaultRegistry();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        InstrumentationModule that = (InstrumentationModule) o;
+        return Objects.equals(healthCheckRegistry, that.healthCheckRegistry) &&
+            Objects.equals(metricsRegistry, that.metricsRegistry);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(healthCheckRegistry, metricsRegistry);
     }
 }

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentationModuleTest.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentationModuleTest.java
@@ -1,17 +1,22 @@
 package com.yammer.metrics.guice.tests;
 
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.yammer.metrics.HealthChecks;
 import com.yammer.metrics.Metrics;
+import com.yammer.metrics.annotation.Timed;
 import com.yammer.metrics.core.HealthCheckRegistry;
+import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.Timer;
 import com.yammer.metrics.guice.InstrumentationModule;
-import org.junit.Test;
-
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 
 public class InstrumentationModuleTest {
     private final InstrumentationModule module = new InstrumentationModule();
@@ -27,5 +32,28 @@ public class InstrumentationModuleTest {
     public void defaultsToTheDefaultHealthCheckRegistry() throws Exception {
         assertThat(injector.getInstance(HealthCheckRegistry.class),
                    is(sameInstance(HealthChecks.defaultRegistry())));
+    }
+
+    @Test
+    public void moduleInstallIsIdempotent() {
+        Injector injector = Guice.createInjector(new InstrumentationModule(), new InstrumentationModule());
+
+        TestTimed instance = injector.getInstance(TestTimed.class);
+
+        MetricName metricName = new MetricName(TestTimed.class, "method");
+        Timer timer = (Timer) Metrics.defaultRegistry().allMetrics().get(metricName);
+
+        assertThat(timer, is(notNullValue()));
+        assertThat(timer.count(), is(0L));
+
+        instance.method();
+
+        assertThat(timer.count(), is(1L));
+    }
+
+    public static class TestTimed {
+
+        @Timed
+        public void method() {}
     }
 }


### PR DESCRIPTION
If `InstrumentationModule` accidentally gets installed twice, it will bind duplicate listeners, which will bind duplicate interceptors, which will cause calls to `@Metered`, `@Timed`, and `@ExceptionMetered` methods to get double-counted. This PR updates `InstrumentationModule` to implement `equals`/`hashCode` so that installing it multiple times is idempotent. I added a test which fails without the corresponding changes to `InstrumentationModule`.

@stevegutz @kmclarnon 