### PR TITLE
Add utility class as a wrapper around Optional<Timer>.

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/util/OptionalTimer.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/util/OptionalTimer.java
@@ -1,0 +1,36 @@
+package com.yammer.metrics.util;
+
+import java.io.Closeable;
+import java.util.Optional;
+
+import com.yammer.metrics.core.Timer;
+
+public class OptionalTimer {
+  private static final Closeable NULL_CLOSEABLE = () -> {};
+  private static final OptionalTimer EMPTY = new OptionalTimer();
+  private final Optional<Timer> timer;
+
+  private OptionalTimer(Timer timer) {
+    this.timer = Optional.of(timer);
+  }
+
+  private OptionalTimer() {
+    this.timer = Optional.empty();
+  }
+
+  public Closeable time() {
+    return timer.<Closeable>map(Timer::time).orElse(NULL_CLOSEABLE);
+  }
+
+  public static OptionalTimer of(Timer timer) {
+    return new OptionalTimer(timer);
+  }
+
+  public static OptionalTimer of(Optional<Timer> timer) {
+    return timer.map(OptionalTimer::new).orElse(EMPTY);
+  }
+
+  public static OptionalTimer empty() {
+    return EMPTY;
+  }
+}


### PR DESCRIPTION
Useful because timers are typically used inside a `try` block which is cumbersome to unwrap `Optional<Timer>` into. 