### PR TITLE
Create mbean name on demand

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -14,4 +14,14 @@
         <Class name="~com\.yammer\.metrics\.spring\..*"/>
         <Bug code="Se"/>
     </Match>
+
+    <!-- Don't care about using \n in format strings -->
+    <Match>
+        <Bug code="FS" />
+    </Match>
+
+    <!-- Don't care about reliance on default encoding -->
+    <Match>
+        <Bug code="Dm" />
+    </Match>
 </FindBugsFilter>

--- a/metrics-log4j/src/main/java/com/yammer/metrics/log4j/InstrumentedAppender.java
+++ b/metrics-log4j/src/main/java/com/yammer/metrics/log4j/InstrumentedAppender.java
@@ -1,14 +1,15 @@
 package com.yammer.metrics.log4j;
 
-import com.yammer.metrics.Metrics;
-import com.yammer.metrics.core.Meter;
-import com.yammer.metrics.core.MetricsRegistry;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.log4j.Appender;
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.Level;
 import org.apache.log4j.spi.LoggingEvent;
 
-import java.util.concurrent.TimeUnit;
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Meter;
+import com.yammer.metrics.core.MetricsRegistry;
 
 /**
  * A Log4J {@link Appender} delegate which has seven meters, one for each logging level and one for
@@ -60,6 +61,8 @@ public class InstrumentedAppender extends AppenderSkeleton {
             case Level.FATAL_INT:
                 fatal.mark();
                 break;
+             default:
+                 // do nothing
         }
     }
 

--- a/metrics-logback/src/main/java/com/yammer/metrics/logback/InstrumentedAppender.java
+++ b/metrics-logback/src/main/java/com/yammer/metrics/logback/InstrumentedAppender.java
@@ -1,14 +1,15 @@
 package com.yammer.metrics.logback;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.Appender;
-import ch.qos.logback.core.AppenderBase;
+import java.util.concurrent.TimeUnit;
+
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Meter;
 import com.yammer.metrics.core.MetricsRegistry;
 
-import java.util.concurrent.TimeUnit;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.AppenderBase;
 
 /**
  * A Logback {@link AppenderBase} which has six meters, one for each logging level and one for the
@@ -54,6 +55,8 @@ public class InstrumentedAppender extends AppenderBase<ILoggingEvent> {
             case Level.ERROR_INT:
                 error.mark();
                 break;
+            default:
+                // do nothing
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>2.3.3</version>
+                <version>3.0.5</version>
                 <configuration>
                     <effort>Max</effort>
                     <threshold>Default</threshold>


### PR DESCRIPTION
Creating the `mBeanName` is the most expensive part about creating a `MetricName`, and it almost never gets used (only used by the JMX reporter). This PR makes it lazily generated so that we're not paying that cost on every `MetricName` creation

@stevegutz @axiak @kmclarnon 